### PR TITLE
Changed version of Linux Deploy to fix appimages.

### DIFF
--- a/CMake/Packaging.cmake
+++ b/CMake/Packaging.cmake
@@ -59,7 +59,7 @@ if (NOT LINUXDEPLOY_EXECUTABLE)
   message(STATUS "Downloading linuxdeploy")
   set(LINUXDEPLOY_EXECUTABLE ${CPACK_PACKAGE_DIRECTORY}/linuxdeploy/linuxdeploy)
   file(DOWNLOAD 
-      https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-x86_64.AppImage
+      https://github.com/linuxdeploy/linuxdeploy/releases/download/1-alpha-20240109-1/linuxdeploy-x86_64.AppImage
       ${LINUXDEPLOY_EXECUTABLE}
       INACTIVITY_TIMEOUT 10
       LOG ${CPACK_PACKAGE_DIRECTORY}/linuxdeploy/download.log


### PR DESCRIPTION
A few months ago github changed the version of Ubuntu they used for the actions runner, this broke appimage generation for SoH/2ship/Starship, Bria fixed it by changing the version of Linux Deploy for those ports but seems that was not applied here yet.

Already verified that it is working after this fix, was not prior.